### PR TITLE
Modify the Jest setup to use Jasmine instead

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@
 - Usar ES6+
 - Seguir guía de estilo Airbnb
 - Documentar funciones con JSDoc
-- Tests unitarios con Jest
+- Tests unitarios con Jasmine
 
 ### Frontend (Angular)
 - Seguir Angular Style Guide oficial
@@ -63,4 +63,4 @@ Seguir Conventional Commits:
 ## Contacto
 Para dudas o sugerencias:
 - Crear un issue
-- Correo: nombre@dominio.com
+- Correo: eduferreyraok@gmail.com

--- a/backend/.github/workflows/backend-deploy.yml
+++ b/backend/.github/workflows/backend-deploy.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm install
 
       - name: Run tests
-        run: npm test
+        run: npx jasmine
 
       - name: Deploy
         if: success()

--- a/backend/.github/workflows/backend-test.yml
+++ b/backend/.github/workflows/backend-test.yml
@@ -25,4 +25,4 @@ jobs:
         run: npm install
 
       - name: Run tests
-        run: npm test
+        run: npx jasmine

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,7 +9,7 @@ Este directorio contiene el código fuente del backend de la aplicación, desarr
 - Express >= 4.x
 - MongoDB >= 4.x
 - Mongoose >= 5.x
-- Jest >= 26.x
+- Jasmine >= 3.x
 
 ## Instalación
 
@@ -71,7 +71,7 @@ Este proyecto está licenciado bajo la Licencia MIT. Consulta el archivo `LICENS
 - [Express](https://expressjs.com/es/)
 - [MongoDB](https://www.mongodb.com/)
 - [Mongoose](https://mongoosejs.com/)
-- [Jest](https://jestjs.io/)
+- [Jasmine](https://jasmine.github.io/)
 
 ## Nota
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "Backend for the fullstack course",
+  "main": "index.js",
+  "scripts": {
+    "test": "npx jasmine"
+  },
+  "dependencies": {
+    "express": "^4.17.1",
+    "mongoose": "^5.10.9"
+  },
+  "devDependencies": {
+    "jasmine": "^3.6.3"
+  },
+  "author": "Carlos Ferreyra",
+  "license": "MIT"
+}


### PR DESCRIPTION
Replace Jest with Jasmine for testing in the backend.

* **Workflows**
  - Replace `npm test` with `npx jasmine` in `backend/.github/workflows/backend-deploy.yml` and `backend/.github/workflows/backend-test.yml`.

* **Package Configuration**
  - Add `backend/package.json` with `jasmine` in `devDependencies` and update the "test" script to use `jasmine`.

* **Documentation**
  - Update `backend/README.md` to replace `Jest` with `Jasmine` in the "Requisitos" and "Documentación" sections.
  - Update `CONTRIBUTING.md` to replace `Jest` with `Jasmine` in the "Tests unitarios con Jest" section.
  - Update `CONTRIBUTING.md` to replace `nombre@dominio.com` with `eduferreyraok@gmail.com` in the "Contacto" section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/carlosferreyra/curso-fullstack-2024/pull/12?shareId=985a87fa-da7b-407c-8d18-1807db34c358).